### PR TITLE
docs: add dedicated incident runbooks for common failure modes

### DIFF
--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,0 +1,46 @@
+<!-- Copyright © 2025 Novatrax Labs LLC. All Rights Reserved. -->
+
+# Incident Runbooks
+
+This directory contains operator-facing incident response playbooks for the highest-value platform failure modes. These runbooks complement, rather than replace, the broader guidance in `docs/DEPLOYMENT.md`, `docs/KAFKA_SETUP.md`, `docs/SECRETS_MANAGEMENT.md`, and `docs/TROUBLESHOOTING.md`.
+
+## How to use these runbooks
+
+1. Stabilize first. Reduce customer impact before optimizing the fix.
+2. Name an incident commander for any customer-facing or security-relevant event.
+3. Record timestamps, actions taken, affected services, and commands run.
+4. Prefer reversible changes and validated rollback paths.
+5. Verify recovery with explicit checks before declaring the incident resolved.
+
+## Severity guide
+
+- **P0**: Full production outage, data integrity risk, or active security incident.
+- **P1**: Major degradation affecting core workflows or many users.
+- **P2**: Partial degradation or single-component failure with safe fallback.
+- **P3**: Low-risk operational issue or warning-only condition.
+
+## Escalation defaults
+
+- **Primary on-call**: SRE / platform operator
+- **Secondary**: Platform lead
+- **Security-sensitive events**: Security owner and platform lead immediately
+- **Customer-facing P0/P1**: Communications lead or customer success owner
+
+## Runbook index
+
+- [LLM Provider Outage](./llm-provider-outage.md)
+- [Database Failover](./database-failover.md)
+- [Message Bus Recovery](./message-bus-recovery.md)
+- [High Error Rate Triage](./high-error-rate-triage.md)
+- [Deployment Rollback](./deployment-rollback.md)
+- [Secret Rotation](./secret-rotation.md)
+
+## Common recovery checklist
+
+Before closing any incident, confirm all of the following:
+
+- Health endpoints return healthy or expected degraded state.
+- Error rate, queue depth, latency, and saturation metrics have stabilized.
+- No active data corruption, replay backlog, or retry storm remains.
+- Monitoring alerts have cleared or been intentionally suppressed with justification.
+- Incident notes and follow-up actions are captured in the ticket or postmortem.

--- a/docs/runbooks/database-failover.md
+++ b/docs/runbooks/database-failover.md
@@ -1,0 +1,73 @@
+<!-- Copyright © 2025 Novatrax Labs LLC. All Rights Reserved. -->
+
+# Runbook: Database Failover
+
+## When to use this runbook
+
+Use this runbook when the primary database is unavailable, unhealthy, too slow to support safe operation, or when failover to a replica is required to preserve service continuity.
+
+## Detection criteria
+
+Trigger this runbook when one or more of the following are true:
+
+- Database connectivity checks fail from application services.
+- Readiness checks fail because the database cannot accept connections.
+- API latency or error rate spikes are dominated by database timeout or connection errors.
+- The primary database is reachable but unable to serve write traffic reliably.
+- Replica lag, failover alarms, or infrastructure alerts indicate primary instability.
+
+## Immediate response
+
+1. Confirm impact.
+   - Identify affected services and whether the issue is read-only, write-only, or total unavailability.
+2. Freeze unsafe change activity.
+   - Halt schema changes, bulk jobs, and manual maintenance while diagnosis is in progress.
+3. Protect data integrity.
+   - Do not fail over to a replica with unacceptable lag.
+   - Capture current replication state before changing writer endpoints.
+4. Execute failover.
+   - Promote the designated healthy replica or switch application traffic to the pre-approved standby.
+   - Update connection targets, service discovery, or secret-backed connection strings as required.
+5. Restart or recycle application connections.
+   - Force stale connection pools to reconnect to the new primary.
+
+## Investigation checklist
+
+- Is the problem isolated to the primary, the network path, or connection exhaustion in the app?
+- What is current replica lag?
+- Were there recent migrations, connection pool changes, or credential changes?
+- Did storage pressure, IOPS exhaustion, or disk saturation trigger the event?
+- Is SQLite dev fallback accidentally in use where a production database is expected?
+
+## Recovery actions
+
+- Promote the healthiest replica that meets lag and durability requirements.
+- Point application services to the new writer endpoint.
+- Recycle workers so pooled connections do not keep using the old primary.
+- Pause replay-heavy or write-heavy background jobs until stability is confirmed.
+- Preserve logs and metadata from the failed primary for later root-cause analysis.
+
+## Recovery verification
+
+Do not close the incident until all of the following are true:
+
+- Write operations succeed against the new primary.
+- Read operations are consistent and do not show stale or split-brain behavior.
+- Connection errors and query timeout alerts have returned toward baseline.
+- Replication topology is understood and documented after failover.
+- Application health checks and at least one end-to-end workflow pass.
+
+## Escalation path
+
+- **P1**: Platform on-call and database owner
+- **P0**: Platform lead immediately
+- **Potential data loss or split-brain risk**: Security owner and leadership immediately
+
+## Follow-up
+
+Capture:
+
+- Failover start and end time
+- Replica lag at decision time
+- Whether connection pooling, DNS, or service discovery slowed recovery
+- Any migrations, hot queries, or capacity issues that contributed to the failure

--- a/docs/runbooks/deployment-rollback.md
+++ b/docs/runbooks/deployment-rollback.md
@@ -1,0 +1,69 @@
+<!-- Copyright © 2025 Novatrax Labs LLC. All Rights Reserved. -->
+
+# Runbook: Deployment Rollback
+
+## When to use this runbook
+
+Use this runbook when a recent deploy causes production instability, customer-visible regressions, dependency mismatches, or safety concerns that can be mitigated faster by reverting than by repairing in place.
+
+## Detection criteria
+
+Trigger this runbook when one or more of the following are true:
+
+- Error rate, latency, or saturation worsens sharply after a deployment.
+- A new release breaks core generation, routing, auth, or persistence paths.
+- Health checks fail only on the new version.
+- Roll-forward confidence is low and rollback is the fastest safe stabilization path.
+- Multiple operators independently identify the release as the most likely trigger.
+
+## Immediate response
+
+1. Halt forward changes.
+   - Freeze further deploys, migrations, or feature-flag expansions until stability returns.
+2. Confirm rollback target.
+   - Identify the last known good version, image tag, or rollout revision.
+3. Check for non-reversible changes.
+   - Confirm whether database migrations, secret format changes, or queue schema changes require extra care.
+4. Roll back using the platform-appropriate mechanism.
+   - Kubernetes: revert the deployment revision.
+   - Docker Compose or equivalent: redeploy the previous known good image and configuration.
+5. Watch health and traffic immediately after rollback begins.
+
+## Investigation checklist
+
+- Which exact commit, image, config, or migration introduced the regression?
+- Is rollback safe without data loss or schema incompatibility?
+- Did the release include hidden dependencies such as secret format or provider changes?
+- Are only some services on the bad version, creating mixed-version behavior?
+
+## Recovery actions
+
+- Revert the affected service or services to the last known good version.
+- If a migration prevents clean rollback, place the system in degraded or read-only mode while you stabilize dependency order.
+- Restart pods or processes only as needed to ensure old code and old config are fully active.
+- Keep the bad release blocked from automatic redeploy until root cause is known.
+
+## Recovery verification
+
+Do not close the incident until all of the following are true:
+
+- The intended previous version is fully serving production traffic.
+- Health checks and golden-path workflows succeed.
+- Error rate and latency have returned toward baseline.
+- No automated system is poised to reintroduce the bad release.
+- Operators have captured the exact release artifact and rollback target in the incident log.
+
+## Escalation path
+
+- **P1**: Platform on-call and release owner
+- **P0**: Platform lead immediately
+- **If rollback is blocked by schema or data risk**: Database owner and security owner as needed
+
+## Follow-up
+
+Capture:
+
+- Release identifier and rollback target
+- Whether rollback was clean or required manual intervention
+- Any migration, feature-flag, or config-ordering issue that complicated reversal
+- Gating changes needed in CI/CD or progressive delivery before redeploying

--- a/docs/runbooks/high-error-rate-triage.md
+++ b/docs/runbooks/high-error-rate-triage.md
@@ -1,0 +1,73 @@
+<!-- Copyright © 2025 Novatrax Labs LLC. All Rights Reserved. -->
+
+# Runbook: High Error Rate Triage
+
+## When to use this runbook
+
+Use this runbook when application error rate rises above normal thresholds and the root cause is not yet known. This is the first-response playbook for broad production instability.
+
+## Detection criteria
+
+Trigger this runbook when one or more of the following are true:
+
+- Error-rate alerts fire for core APIs or worker pipelines.
+- A sudden increase in 4xx or 5xx responses appears across multiple endpoints.
+- Queue backlog, timeout rate, or saturation metrics rise together with application errors.
+- Health checks remain technically up but customer workflows are failing.
+- Multiple downstream runbooks may apply, but the dominant failure mode is not yet identified.
+
+## Immediate response
+
+1. Triage severity.
+   - P0 if core production workflows are broadly unavailable.
+   - P1 if major workflows are degraded but partial service remains.
+2. Establish incident command.
+   - Assign an incident commander and start a timestamped incident log.
+3. Confirm blast radius.
+   - Identify affected endpoints, stages, regions, tenants, or internal subsystems.
+4. Check the change window.
+   - Ask what changed immediately before the spike: deploy, secret change, traffic surge, quota event, schema change, or broker instability.
+5. Mitigate fast.
+   - Roll back the last risky change if the correlation is strong and rollback is low risk.
+   - Rate-limit or temporarily disable the narrowest failing path if it protects the rest of the platform.
+
+## Investigation checklist
+
+- Are errors concentrated in one endpoint, one stage, or one dependency?
+- Are they 4xx client errors, 5xx server errors, or timeout-related failures?
+- Do logs point to database, message bus, provider, auth, or deployment causes?
+- Is the spike caused by saturation: CPU, memory, connection pools, queue depth, or rate limits?
+- Is the system healthy but one new release or config change is misbehaving?
+
+## Recovery actions
+
+- Route to a more specific runbook as soon as a dominant cause is identified.
+- Apply the smallest reversible mitigation first.
+- Roll back bad config or code changes quickly when evidence supports it.
+- Restart only the failing component unless a wider recycle is clearly justified.
+- Keep communication updates frequent for P0/P1 incidents.
+
+## Recovery verification
+
+Do not close the incident until all of the following are true:
+
+- Error rate is back within expected bounds.
+- Latency and queue metrics have stabilized.
+- At least one full customer workflow passes.
+- The immediate triggering factor is understood well enough to prevent blind recurrence.
+- A follow-up owner is assigned if the deeper fix is not yet complete.
+
+## Escalation path
+
+- **P1**: Platform on-call and platform lead
+- **P0**: Platform lead immediately, plus customer communications owner if externally visible
+- **Security or auth anomalies**: Security owner as well
+
+## Follow-up
+
+Capture:
+
+- Exact time the spike began and ended
+- Triggering change or dependency failure, if known
+- Whether rollback, throttling, or restart resolved the issue
+- What alert or dashboard should be tightened based on the incident

--- a/docs/runbooks/llm-provider-outage.md
+++ b/docs/runbooks/llm-provider-outage.md
@@ -1,0 +1,76 @@
+<!-- Copyright © 2025 Novatrax Labs LLC. All Rights Reserved. -->
+
+# Runbook: LLM Provider Outage
+
+## When to use this runbook
+
+Use this runbook when one or more configured LLM providers are unavailable, timing out, rate-limiting heavily, or returning malformed responses that block generation or repair workflows.
+
+## Detection criteria
+
+Trigger this runbook when one or more of the following are true:
+
+- A sustained spike in 5xx responses or timeout errors from provider APIs.
+- Provider-specific authentication or quota errors begin appearing across multiple jobs.
+- Generation, critique, or clarifier stages stall because no provider can complete requests.
+- Health checks or diagnostics show zero available providers while requests are actively arriving.
+- Alerting shows high retry volume, rising queue age, or cascading stage failures tied to LLM calls.
+
+## Immediate response
+
+1. Confirm scope.
+   - Determine whether the outage affects one provider or all configured providers.
+   - Identify which user-facing workflows are degraded: codegen, testgen, deploy, docgen, critique, or clarifier.
+2. Reduce blast radius.
+   - Shift traffic to healthy providers if multi-provider configuration is available.
+   - Disable nonessential LLM-heavy background work if it is starving primary workflows.
+   - If no provider is healthy, place affected endpoints into a clearly signaled degraded mode.
+3. Validate credentials and quotas.
+   - Check whether failures are caused by expired keys, quota exhaustion, or provider-side service errors.
+   - Confirm environment variables and secret injection still match expected production values.
+4. Protect the queue.
+   - Slow or pause retry loops that are amplifying provider errors.
+   - Watch for growing job backlog and dead-letter behavior.
+5. Communicate impact.
+   - Mark the incident as P1 or P0 depending on whether core generation is unavailable.
+   - Notify the platform lead if no healthy fallback exists.
+
+## Investigation checklist
+
+- Which provider is failing?
+- Are errors consistent across regions, workers, and stages?
+- Did the incident start immediately after a config, dependency, or credential change?
+- Are failures hard errors, slow responses, or partial malformed outputs?
+- Is the fallback provider configured but not selected, or unavailable entirely?
+
+## Recovery actions
+
+- Re-route traffic to an alternate provider.
+- Correct invalid or rotated credentials if the provider itself is healthy.
+- Increase provider timeout or lower concurrency only if the provider is slow rather than down.
+- Re-enable paused queues gradually after provider health stabilizes.
+- Retry only the failed or stuck jobs after healthy provider response is confirmed.
+
+## Recovery verification
+
+Do not close the incident until all of the following are true:
+
+- Provider health checks succeed consistently.
+- At least one end-to-end generation workflow completes successfully.
+- Queue age, retry count, and timeout rates return toward baseline.
+- Error logs no longer show sustained provider outage symptoms.
+- Operators confirm user-visible workflow recovery in API and CLI paths.
+
+## Escalation path
+
+- **P1**: Platform on-call and platform lead
+- **P0**: Platform lead immediately; customer communications owner if the public API is materially degraded
+- **Security-sensitive credential failure**: Security owner as well
+
+## Follow-up
+
+Capture:
+
+- Affected providers and time window
+- Whether fallback routing worked as designed
+- Needed changes to quotas, alerts, provider prioritization, or retry policy

--- a/docs/runbooks/message-bus-recovery.md
+++ b/docs/runbooks/message-bus-recovery.md
@@ -1,0 +1,69 @@
+<!-- Copyright © 2025 Novatrax Labs LLC. All Rights Reserved. -->
+
+# Runbook: Message Bus Recovery
+
+## When to use this runbook
+
+Use this runbook when the platform message bus is unavailable, dispatchers are not running, queues are stuck, events are being dropped, or downstream workers stop receiving routed jobs.
+
+## Detection criteria
+
+Trigger this runbook when one or more of the following are true:
+
+- Job routing succeeds at the API layer but no downstream processing begins.
+- Queue depth grows while worker throughput drops toward zero.
+- Dead-letter volume spikes or retry storms begin.
+- Health checks show the message bus as unavailable or dispatcher tasks not started.
+- WebSocket or event-stream consumers stop receiving expected lifecycle events.
+
+## Immediate response
+
+1. Confirm whether the failure is in the bus, the broker bridge, or downstream workers.
+2. Stabilize producers.
+   - Slow or pause nonessential publishers if queue growth threatens memory or storage safety.
+3. Check dispatcher state.
+   - Verify the message bus instance exists, dispatcher tasks are running, and the component is marked available.
+4. Check broker dependencies.
+   - Verify Redis, Kafka, or any configured bridge dependencies are reachable and healthy.
+5. Restart the smallest safe unit.
+   - Prefer restarting failed dispatcher tasks or the affected worker before recycling the full stack.
+
+## Investigation checklist
+
+- Are messages failing to publish, publish but not dispatch, or dispatch but not process?
+- Is the fault inside the in-process bus, the Redis/Kafka bridge, or the subscriber layer?
+- Did the incident begin after a deploy or config change?
+- Are dead-letter and retry settings amplifying the outage?
+- Are workers healthy but subscribed to the wrong topics or callbacks?
+
+## Recovery actions
+
+- Restore broker connectivity.
+- Restart or recreate failed dispatcher tasks.
+- Reconnect subscribers and verify expected topic bindings.
+- Drain or replay dead-lettered messages only after the root cause is controlled.
+- Resume paused publishers gradually to avoid an immediate second backlog wave.
+
+## Recovery verification
+
+Do not close the incident until all of the following are true:
+
+- New jobs are routed and processed end-to-end.
+- Queue depth and dead-letter volume trend down toward baseline.
+- Subscribers receive expected lifecycle events again.
+- No dispatcher task is repeatedly crashing or restarting.
+- Error logs no longer show publish, subscribe, or bridge connectivity failures.
+
+## Escalation path
+
+- **P1**: Platform on-call and message-bus owner
+- **P0**: Platform lead immediately
+- **If data loss or dropped event ordering is suspected**: Escalate to leadership and capture forensic detail before replay
+
+## Follow-up
+
+Capture:
+
+- Whether the outage originated in the bus implementation, external broker, or subscriber layer
+- Backlog size and replay volume
+- Any retry-policy or dead-letter-policy changes required to prevent recurrence

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -1,0 +1,73 @@
+<!-- Copyright © 2025 Novatrax Labs LLC. All Rights Reserved. -->
+
+# Runbook: Secret Rotation
+
+## When to use this runbook
+
+Use this runbook for scheduled secret rotation and for emergency rotation when a credential may be exposed, expired, misissued, or otherwise untrusted.
+
+## Detection criteria
+
+Trigger this runbook when one or more of the following are true:
+
+- A credential has reached its scheduled rotation window.
+- A provider key, JWT secret, database password, or broker credential may be compromised.
+- Authentication failures begin after a secret change and state is uncertain.
+- Security tooling, audit review, or operator action identifies a secret handling concern.
+
+## Immediate response
+
+1. Classify urgency.
+   - Emergency rotation if compromise is suspected.
+   - Planned rotation if this is routine lifecycle maintenance.
+2. Identify dependencies.
+   - List every service, worker, job, provider, and environment that reads the secret.
+3. Prepare replacement value.
+   - Generate the new secret in the approved secret manager.
+   - Do not place raw secrets in tickets, logs, chat, or source control.
+4. Update consumers safely.
+   - Prefer staged rollout if dual-read or overlapping validity is supported.
+   - Restart or recycle services that do not reload secrets dynamically.
+5. Revoke the old value.
+   - Remove or disable the previous credential as soon as all required consumers are confirmed healthy.
+
+## Investigation checklist
+
+- Which exact secret is rotating?
+- Which systems depend on it?
+- Can the old and new values overlap safely during cutover?
+- Are there cached tokens, pooled connections, or background workers that will keep using the old secret?
+- Is this rotation triggered by compromise, expiry, or routine policy?
+
+## Recovery actions
+
+- Generate and store the new credential in the approved secret backend.
+- Roll out the new value to all dependent services.
+- Restart or redeploy services that require process restart for secret reload.
+- Revoke the old value only after health checks and consumer validation pass.
+- For emergency rotation, shorten the incident loop and preserve evidence for later review.
+
+## Recovery verification
+
+Do not close the incident or maintenance window until all of the following are true:
+
+- Every dependent service authenticates successfully with the new secret.
+- No logs or alerts show continued use of the old credential.
+- The previous secret is revoked or disabled.
+- At least one golden-path workflow using the rotated secret succeeds.
+- Rotation details are recorded without exposing the secret material itself.
+
+## Escalation path
+
+- **Planned rotation**: Platform on-call or service owner
+- **Emergency rotation**: Security owner and platform lead immediately
+- **Broad auth failure after rotation**: Platform lead and affected service owners
+
+## Follow-up
+
+Capture:
+
+- Systems touched by the rotation
+- Whether overlapping validity was available
+- Which services required restart versus live reload
+- Any logging or operational hygiene issues discovered during rotation


### PR DESCRIPTION
## Summary
- add a dedicated `docs/runbooks/` incident-response surface
- add an operator index plus concrete runbooks for the highest-value failure modes
- cover detection criteria, immediate response, escalation, recovery, and verification in each playbook

## Runbooks added
- LLM provider outage
- Database failover
- Message bus recovery
- High error rate triage
- Deployment rollback
- Secret rotation

## Why
The repo already had broader operational documentation, but it lacked the dedicated incident playbooks requested in issue #1802.

Closes #1802